### PR TITLE
Remove reference to non-existing service/class

### DIFF
--- a/src/App/Bundle/Resources/services/services.yml
+++ b/src/App/Bundle/Resources/services/services.yml
@@ -16,9 +16,3 @@ services:
         arguments: ['@validator']
         tags:
             - { name: command_bus_middleware }
-
-    app.validator.unique:
-        class: App\Bundle\Validator\UniqueValidator
-        arguments: ['@doctrine']
-        tags:
-            - { name: validator.constraint_validator, alias: app.validator.unique }


### PR DESCRIPTION
There's a reference to a service where the class does not exist. This removes it.
